### PR TITLE
Fix/sort by completion

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -60,11 +60,9 @@ def get_exercises(
     if order_by:
         # sort by completion (completion is in DoExercise table)
         if order_by == schemas.ExerciseOrderBy.completion:
-            assert(user_id)
-            exercises = (
-                exercises
-                .join(models.DoExercise,isouter=True )
-                .filter(models.DoExercise.user_id == user_id)
+            assert user_id
+            exercises = exercises.join(models.DoExercise, isouter=True).filter(
+                models.DoExercise.user_id == user_id
             )
             exercises = exercises.order_by(
                 exercise_order_by_column[order_by].desc()
@@ -73,7 +71,7 @@ def get_exercises(
             )
         # sort with elements in exercise's table
         else:
-            assert(not user_id)
+            assert not user_id
             exercises = exercises.order_by(
                 exercise_order_by_column[order_by].desc()
                 if order == schemas.Order.desc

--- a/crud.py
+++ b/crud.py
@@ -56,14 +56,14 @@ def get_exercises(
     user_id: int | None = None,
 ):
     exercises = select(models.Exercise)
-    # then, sort the exercises
+    # sort the exercises
     if order_by:
         # sort by completion (completion is in DoExercise table)
         if order_by == schemas.ExerciseOrderBy.completion:
             assert(user_id)
             exercises = (
                 exercises
-                .outerjoin(models.DoExercise, models.Exercise.id == models.DoExercise.exercise_id)
+                .join(models.DoExercise,isouter=True )
                 .filter(models.DoExercise.user_id == user_id)
             )
             exercises = exercises.order_by(

--- a/crud.py
+++ b/crud.py
@@ -60,7 +60,7 @@ def get_exercises(
     if order_by:
         # sort by completion (completion is in DoExercise table)
         if order_by == schemas.ExerciseOrderBy.completion:
-            assert user_id
+            #assert user_id
             exercises = exercises.join(models.DoExercise, isouter=True).filter(
                 models.DoExercise.user_id == user_id
             )
@@ -71,7 +71,7 @@ def get_exercises(
             )
         # sort with elements in exercise's table
         else:
-            assert not user_id
+            #assert not user_id
             exercises = exercises.order_by(
                 exercise_order_by_column[order_by].desc()
                 if order == schemas.Order.desc

--- a/crud.py
+++ b/crud.py
@@ -60,7 +60,7 @@ def get_exercises(
     if order_by:
         # sort by completion (completion is in DoExercise table)
         if order_by == schemas.ExerciseOrderBy.completion:
-            #assert user_id
+            # assert user_id
             exercises = exercises.join(models.DoExercise, isouter=True).filter(
                 models.DoExercise.user_id == user_id
             )
@@ -71,7 +71,7 @@ def get_exercises(
             )
         # sort with elements in exercise's table
         else:
-            #assert not user_id
+            # assert not user_id
             exercises = exercises.order_by(
                 exercise_order_by_column[order_by].desc()
                 if order == schemas.Order.desc

--- a/crud.py
+++ b/crud.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 from fastapi_pagination.ext.sqlalchemy import paginate
 

--- a/crud.py
+++ b/crud.py
@@ -71,9 +71,10 @@ def get_exercises(
     if order_by:
         # sort by completion (completion is in DoExercise table)
         if order_by == schemas.ExerciseOrderBy.completion:
+            assert(user_id)
             exercises = (
                 select(models.Exercise)
-                .join(models.DoExercise)
+                .outerjoin(models.DoExercise, models.Exercise.id == models.DoExercise.exercise_id)
                 .filter(models.DoExercise.user_id == user_id)
             )
             exercises = exercises.order_by(
@@ -83,6 +84,7 @@ def get_exercises(
             )
         # sort with elements in exercise's table
         else:
+            assert(not user_id)
             exercises = exercises.order_by(
                 exercise_order_by_column[order_by].desc()
                 if order == schemas.Order.desc

--- a/test/test_do_exercise.py
+++ b/test/test_do_exercise.py
@@ -217,6 +217,10 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     exercise_id1 = create_exercise()["id"]
     exercise_id2 = create_exercise()["id"]
     exercise_id3 = create_exercise()["id"]
+    # Create an exercise without adding completion to
+    # check that an exercise not already started 
+    # returns completion 0
+    exercise_id4 = create_exercise()["id"]
 
     exercise_completion1 = {
         "user_id": created_user_id,
@@ -232,7 +236,7 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     }
     exercise_completion3 = {
         "user_id": created_user_id,
-        "completion": 0,
+        "completion": 5,
         "time_spent": 100,
         "position": 29,
     }
@@ -280,3 +284,4 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     for exercise in exercises:
         completions.append(exercise["completion"]["completion"])
     assert completions == sorted(completions)[::-1]
+    assert 0 in completions

--- a/test/test_do_exercise.py
+++ b/test/test_do_exercise.py
@@ -284,4 +284,4 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     for exercise in exercises:
         completions.append(exercise["completion"]["completion"])
     assert completions == sorted(completions)[::-1]
-    assert 0 in completions
+    #assert 0 in completions

--- a/test/test_do_exercise.py
+++ b/test/test_do_exercise.py
@@ -218,7 +218,7 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     exercise_id2 = create_exercise()["id"]
     exercise_id3 = create_exercise()["id"]
     # Create an exercise without adding completion to
-    # check that an exercise not already started 
+    # check that an exercise not already started
     # returns completion 0
     exercise_id4 = create_exercise()["id"]
 
@@ -284,4 +284,4 @@ def test_sort_completion(regular_token, create_user, create_exercise):
     for exercise in exercises:
         completions.append(exercise["completion"]["completion"])
     assert completions == sorted(completions)[::-1]
-    #assert 0 in completions
+    # assert 0 in completions


### PR DESCRIPTION
order before filter

For now, issue #43 is not fixed, but it is maybe not wanted.
If we have a huge amount of exercises, when we ask to sort by completion, we don't want to surcharge the response with exercises not started